### PR TITLE
get rid of compilation warnings (tested on Elixir 1.8.2 to 1.10.4)

### DIFF
--- a/lib/linguist/compiler.ex
+++ b/lib/linguist/compiler.ex
@@ -38,7 +38,7 @@ defmodule Linguist.Compiler do
   @simple_interpol "%{"
 
   def compile(translations) do
-    langs = Dict.keys translations
+    langs = Keyword.keys translations
     translations =
       for {locale, source} <- translations do
         deftranslations(to_string(locale), "", source)
@@ -78,11 +78,11 @@ defmodule Linguist.Compiler do
   end
 
   defp interpolate(string, var) do
-    @interpol_rgx 
+    @interpol_rgx
       |> Regex.split(string, on: [:head, :tail])
       |> Enum.reduce( "", fn
       <<"%{" <> rest>>, acc ->
-        key      = String.to_atom(String.rstrip(rest, ?}))
+        key      = String.to_atom(String.trim_trailing(rest, "}"))
         bindings = Macro.var(var, __MODULE__)
         quote do
           unquote(acc) <> to_string(Dict.fetch!(unquote(bindings), unquote(key)))


### PR DESCRIPTION
By testing this, I stumbled upon the fact that `--warnings-as-errors` is broken on Elixir v1.10 ([issue](https://github.com/elixir-lang/elixir/issues/10073)) and [will only be fixed on Elixir v1.11](https://github.com/elixir-lang/elixir/issues/10073#issuecomment-638251601).